### PR TITLE
Updated changelog.md (0.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - RPC protocol module
 - REST protocol module
 
+## [0.0.5] (2016-08-25)
+- Tied in Guzzle6 as dependency. Removed the php-http/plugins php-http-client dependency (for now)
+- Added Travis-CI support 
+
 ## [0.0.1] (2016-04-25)
 - pre-release


### PR DESCRIPTION
- Tied in Guzzle6 as dependency. Removed the php-http/plugins php-http-client dependency (for now)
- Added Travis-CI support 
